### PR TITLE
feat(otel): add custom latency buckets and API operation labels

### DIFF
--- a/internal/adapters/common/retry_client.go
+++ b/internal/adapters/common/retry_client.go
@@ -251,4 +251,3 @@ func (r *RetryRoundTripper) getBackoff(
 	jitter := rand.Int63n(int64(backoff))
 	return time.Duration(jitter)
 }
-

--- a/internal/adapters/common/retry_client.go
+++ b/internal/adapters/common/retry_client.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -160,17 +161,22 @@ func (r *RetryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 			statusCode = resp.StatusCode
 		}
 
+		operation := classifyEndpoint(req)
+
 		// Record metrics
 		APIRequestsTotal.Add(ctx, 1, metric.WithAttributes(
 			attribute.String("provider", r.ProviderID),
+			attribute.String("operation", operation),
 			attribute.Int("status_code", statusCode),
 		))
 		APILatency.Record(ctx, latency, metric.WithAttributes(
 			attribute.String("provider", r.ProviderID),
+			attribute.String("operation", operation),
 		))
 		if attempt > 0 {
 			APIRetriesTotal.Add(ctx, 1, metric.WithAttributes(
 				attribute.String("provider", r.ProviderID),
+				attribute.String("operation", operation),
 				attribute.Int("attempt", attempt),
 				attribute.Int("status_code", statusCode),
 			))
@@ -180,6 +186,7 @@ func (r *RetryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 		span.SetAttributes(
 			attribute.String("http.method", req.Method),
 			attribute.String("http.url", req.URL.String()),
+			attribute.String("http.operation", operation),
 			attribute.Int("http.status_code", statusCode),
 			attribute.Int("retry.attempt", attempt),
 		)
@@ -230,3 +237,62 @@ func (r *RetryRoundTripper) getBackoff(
 	jitter := rand.Int63n(int64(backoff))
 	return time.Duration(jitter)
 }
+
+func classifyEndpoint(req *http.Request) string {
+	path := req.URL.Path
+	method := req.Method
+
+	// Spotify
+	if req.URL.Host == "api.spotify.com" || strings.Contains(req.URL.Host, "spotify") {
+		if strings.Contains(path, "/v1/search") {
+			return "Search"
+		}
+		if strings.Contains(path, "/v1/playlists") {
+			if method == "GET" {
+				return "PlaylistFetch"
+			}
+			return "PlaylistModify"
+		}
+		if strings.Contains(path, "/v1/me/playlists") {
+			return "ListPlaylists"
+		}
+		return "Other"
+	}
+
+	// YouTube
+	if req.URL.Host == "www.googleapis.com" || strings.Contains(path, "/youtube/v3") {
+		if strings.Contains(path, "/youtube/v3/search") {
+			return "Search"
+		}
+		if strings.Contains(path, "/youtube/v3/playlistItems") {
+			return "PlaylistItemModify"
+		}
+		if strings.Contains(path, "/youtube/v3/playlists") {
+			return "PlaylistModify"
+		}
+		if strings.Contains(path, "/youtube/v3/videos/rate") {
+			return "VideoRate"
+		}
+		return "Other"
+	}
+
+	// Tidal
+	if strings.Contains(req.URL.Host, "tidal") || strings.Contains(path, "/v1") {
+		if strings.Contains(path, "/search") {
+			return "Search"
+		}
+		if strings.Contains(path, "/playlists") {
+			if method == "GET" {
+				return "PlaylistFetch"
+			}
+			return "PlaylistModify"
+		}
+		if strings.Contains(path, "/my-playlists") {
+			return "ListPlaylists"
+		}
+		return "Other"
+	}
+
+	return "Other"
+}
+

--- a/internal/adapters/common/retry_client.go
+++ b/internal/adapters/common/retry_client.go
@@ -9,7 +9,6 @@ import (
 	"math/rand"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -43,6 +42,21 @@ func GetRetryHook(ctx context.Context) OnRetryHook {
 		return hook
 	}
 	return nil
+}
+
+type operationKey struct{}
+
+// WithOperation attaches a logical operation name (e.g. "Search") to the context.
+func WithOperation(ctx context.Context, op string) context.Context {
+	return context.WithValue(ctx, operationKey{}, op)
+}
+
+// GetOperation retrieves the operation name from the context, defaulting to "Other".
+func GetOperation(ctx context.Context) string {
+	if op, ok := ctx.Value(operationKey{}).(string); ok {
+		return op
+	}
+	return "Other"
 }
 
 // ErrorClassifier classifies an HTTP response/error to decide whether it's retriable, and how long to wait.
@@ -161,7 +175,7 @@ func (r *RetryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 			statusCode = resp.StatusCode
 		}
 
-		operation := classifyEndpoint(req)
+		operation := GetOperation(req.Context())
 
 		// Record metrics
 		APIRequestsTotal.Add(ctx, 1, metric.WithAttributes(
@@ -236,63 +250,5 @@ func (r *RetryRoundTripper) getBackoff(
 
 	jitter := rand.Int63n(int64(backoff))
 	return time.Duration(jitter)
-}
-
-func classifyEndpoint(req *http.Request) string {
-	path := req.URL.Path
-	method := req.Method
-
-	// Spotify
-	if req.URL.Host == "api.spotify.com" || strings.Contains(req.URL.Host, "spotify") {
-		if strings.Contains(path, "/v1/search") {
-			return "Search"
-		}
-		if strings.Contains(path, "/v1/playlists") {
-			if method == "GET" {
-				return "PlaylistFetch"
-			}
-			return "PlaylistModify"
-		}
-		if strings.Contains(path, "/v1/me/playlists") {
-			return "ListPlaylists"
-		}
-		return "Other"
-	}
-
-	// YouTube
-	if req.URL.Host == "www.googleapis.com" || strings.Contains(path, "/youtube/v3") {
-		if strings.Contains(path, "/youtube/v3/search") {
-			return "Search"
-		}
-		if strings.Contains(path, "/youtube/v3/playlistItems") {
-			return "PlaylistItemModify"
-		}
-		if strings.Contains(path, "/youtube/v3/playlists") {
-			return "PlaylistModify"
-		}
-		if strings.Contains(path, "/youtube/v3/videos/rate") {
-			return "VideoRate"
-		}
-		return "Other"
-	}
-
-	// Tidal
-	if strings.Contains(req.URL.Host, "tidal") || strings.Contains(path, "/v1") {
-		if strings.Contains(path, "/search") {
-			return "Search"
-		}
-		if strings.Contains(path, "/playlists") {
-			if method == "GET" {
-				return "PlaylistFetch"
-			}
-			return "PlaylistModify"
-		}
-		if strings.Contains(path, "/my-playlists") {
-			return "ListPlaylists"
-		}
-		return "Other"
-	}
-
-	return "Other"
 }
 

--- a/internal/adapters/common/telemetry.go
+++ b/internal/adapters/common/telemetry.go
@@ -87,12 +87,23 @@ func InitTelemetry(ctx context.Context) func(context.Context) {
 		log.Println("ℹ️  OTEL_EXPORTER_OTLP_ENDPOINT not set. OTLP tracing and metrics pushing are disabled (metrics served via local /metrics only).")
 	}
 
-	// 2. Setup MeterProvider with all registered readers
+	// 2. Setup MeterProvider with all registered readers and views
 	var sdkReaders []sdkmetric.Option
 	for _, r := range meterReaders {
 		sdkReaders = append(sdkReaders, sdkmetric.WithReader(r))
 	}
 	sdkReaders = append(sdkReaders, sdkmetric.WithResource(res))
+
+	// Configure custom explicit bucket boundaries for latency histogram (in seconds)
+	latencyView := sdkmetric.NewView(
+		sdkmetric.Instrument{Name: "portify_api_latency_seconds"},
+		sdkmetric.Stream{
+			Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
+				Boundaries: []float64{0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 4.0, 5.0, 7.5, 10.0},
+			},
+		},
+	)
+	sdkReaders = append(sdkReaders, sdkmetric.WithView(latencyView))
 
 	mp := sdkmetric.NewMeterProvider(sdkReaders...)
 	otel.SetMeterProvider(mp)

--- a/internal/adapters/common/telemetry_test.go
+++ b/internal/adapters/common/telemetry_test.go
@@ -38,15 +38,18 @@ func TestTelemetry_Disabled(t *testing.T) {
 
 	APIRequestsTotal.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("provider", "youtube"),
+		attribute.String("operation", "Search"),
 		attribute.Int("status_code", 200),
 	))
 
 	APILatency.Record(ctx, 0.25, metric.WithAttributes(
 		attribute.String("provider", "youtube"),
+		attribute.String("operation", "Search"),
 	))
 
 	APIRetriesTotal.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("provider", "youtube"),
+		attribute.String("operation", "Search"),
 		attribute.Int("attempt", 1),
 		attribute.Int("status_code", 429),
 	))

--- a/internal/adapters/spotify/spotify.go
+++ b/internal/adapters/spotify/spotify.go
@@ -48,6 +48,7 @@ func (a *Adapter) Info() domain.ProviderInfo {
 }
 
 func (a *Adapter) ListPlaylists(ctx context.Context, authToken string) ([]*converterv1.CanonicalPlaylist, error) {
+	ctx = common.WithOperation(ctx, "ListPlaylists")
 	httpClient := a.GetHTTPClient(ctx, authToken)
 	client := sp.New(httpClient)
 
@@ -69,6 +70,7 @@ func (a *Adapter) ListPlaylists(ctx context.Context, authToken string) ([]*conve
 
 // FetchPlaylist fetches a complete playlist from Spotify and maps it to the generic CanonicalPlaylist
 func (a *Adapter) FetchPlaylist(ctx context.Context, playlistID string, authToken string) (*converterv1.CanonicalPlaylist, error) {
+	ctx = common.WithOperation(ctx, "PlaylistFetch")
 	httpClient := a.GetHTTPClient(ctx, authToken)
 	client := sp.New(httpClient)
 
@@ -133,6 +135,7 @@ func (a *Adapter) FetchPlaylist(ctx context.Context, playlistID string, authToke
 // CreatePlaylist creates a new, empty playlist on Spotify.
 // Returns the platform-specific playlist ID.
 func (a *Adapter) CreatePlaylist(ctx context.Context, name string, description string, authToken string) (string, error) {
+	ctx = common.WithOperation(ctx, "PlaylistModify")
 	httpClient := a.GetHTTPClient(ctx, authToken)
 	client := sp.New(httpClient)
 
@@ -168,6 +171,7 @@ func (a *Adapter) CreatePlaylist(ctx context.Context, name string, description s
 }
 
 func (a *Adapter) MatchTrack(ctx context.Context, track *converterv1.CanonicalTrack, authToken string) (string, error) {
+	ctx = common.WithOperation(ctx, "Search")
 	httpClient := a.GetHTTPClient(ctx, authToken)
 	client := sp.New(httpClient)
 
@@ -233,6 +237,7 @@ func (a *Adapter) MatchTrack(ctx context.Context, track *converterv1.CanonicalTr
 
 // AddTrackToPlaylist inserts a single matched track into a playlist.
 func (a *Adapter) AddTrackToPlaylist(ctx context.Context, playlistID string, trackID string, authToken string) error {
+	ctx = common.WithOperation(ctx, "PlaylistModify")
 	httpClient := a.GetHTTPClient(ctx, authToken)
 	client := sp.New(httpClient)
 

--- a/internal/adapters/tidal/tidal.go
+++ b/internal/adapters/tidal/tidal.go
@@ -125,6 +125,7 @@ func (a *Adapter) doRequest(ctx context.Context, authToken, method, path string,
 
 // ListPlaylists fetches the user's existing Tidal playlists.
 func (a *Adapter) ListPlaylists(ctx context.Context, authToken string) ([]*converterv1.CanonicalPlaylist, error) {
+	ctx = common.WithOperation(ctx, "ListPlaylists")
 	// Use the correct v2 endpoint discovered from Tidal API spec
 	// /playlists?filter[owners.id]=me fetches playlists created by the user
 	endpoint := "/playlists?filter[owners.id]=me"
@@ -163,6 +164,7 @@ func (a *Adapter) ListPlaylists(ctx context.Context, authToken string) ([]*conve
 
 // FetchPlaylist retrieves a single playlist by ID
 func (a *Adapter) FetchPlaylist(ctx context.Context, playlistID string, authToken string) (*converterv1.CanonicalPlaylist, error) {
+	ctx = common.WithOperation(ctx, "PlaylistFetch")
 	// Request tracks and their associated artists and albums
 	resp, err := a.doRequest(ctx, authToken, http.MethodGet, "/playlists/"+playlistID+"?include=items,items.artists,items.albums", nil)
 	if err != nil {
@@ -256,6 +258,7 @@ func (a *Adapter) FetchPlaylist(ctx context.Context, playlistID string, authToke
 }
 
 func (a *Adapter) CreatePlaylist(ctx context.Context, name string, description string, authToken string) (string, error) {
+	ctx = common.WithOperation(ctx, "PlaylistModify")
 	payload := map[string]interface{}{
 		"data": map[string]interface{}{
 			"type": "playlists",
@@ -283,6 +286,7 @@ func (a *Adapter) CreatePlaylist(ctx context.Context, name string, description s
 }
 
 func (a *Adapter) MatchTrack(ctx context.Context, track *converterv1.CanonicalTrack, authToken string) (string, error) {
+	ctx = common.WithOperation(ctx, "Search")
 	// 1. Try matching by ISRC first if available
 	if track.Isrc != "" {
 		endpoint := fmt.Sprintf("/tracks?filter[isrc]=%s&countryCode=US", url.QueryEscape(track.Isrc))
@@ -371,6 +375,7 @@ func (a *Adapter) MatchTrack(ctx context.Context, track *converterv1.CanonicalTr
 }
 
 func (a *Adapter) AddTrackToPlaylist(ctx context.Context, playlistID string, trackID string, authToken string) error {
+	ctx = common.WithOperation(ctx, "PlaylistModify")
 	payload := map[string]interface{}{
 		"data": []map[string]interface{}{
 			{

--- a/internal/adapters/youtube/youtube.go
+++ b/internal/adapters/youtube/youtube.go
@@ -59,12 +59,13 @@ func (a *Adapter) Info() domain.ProviderInfo {
 
 // ListPlaylists fetches the user's existing YouTube playlists.
 func (a *Adapter) ListPlaylists(ctx context.Context, authToken string) ([]*converterv1.CanonicalPlaylist, error) {
+	ctx = common.WithOperation(ctx, "ListPlaylists")
 	service, err := a.newService(ctx, authToken)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create YouTube client: %w", err)
 	}
 
-	call := service.Playlists.List([]string{"snippet"}).Mine(true).MaxResults(50)
+	call := service.Playlists.List([]string{"snippet"}).Mine(true).MaxResults(50).Context(ctx)
 	response, err := call.Do()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list youtube playlists: %w", err)
@@ -84,13 +85,14 @@ func (a *Adapter) ListPlaylists(ctx context.Context, authToken string) ([]*conve
 
 // FetchPlaylist retrieves a single playlist by ID, including ALL tracks with full metadata.
 func (a *Adapter) FetchPlaylist(ctx context.Context, playlistID string, authToken string) (*converterv1.CanonicalPlaylist, error) {
+	ctx = common.WithOperation(ctx, "PlaylistFetch")
 	service, err := a.newService(ctx, authToken)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create YouTube client: %w", err)
 	}
 
 	// Fetch playlist metadata (Name, Description)
-	call := service.Playlists.List([]string{"snippet"}).Id(playlistID)
+	call := service.Playlists.List([]string{"snippet"}).Id(playlistID).Context(ctx)
 	playlistRes, err := call.Do()
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch playlist metadata: %w", err)
@@ -110,7 +112,8 @@ func (a *Adapter) FetchPlaylist(ctx context.Context, playlistID string, authToke
 	for {
 		itemsCall := service.PlaylistItems.List([]string{"snippet"}).
 			PlaylistId(playlistID).
-			MaxResults(50)
+			MaxResults(50).
+			Context(ctx)
 
 		if pageToken != "" {
 			itemsCall = itemsCall.PageToken(pageToken)
@@ -158,6 +161,7 @@ func (a *Adapter) FetchPlaylist(ctx context.Context, playlistID string, authToke
 // CreatePlaylist creates a new, empty playlist on YouTube.
 // Returns the platform-specific playlist ID.
 func (a *Adapter) CreatePlaylist(ctx context.Context, name string, description string, authToken string) (string, error) {
+	ctx = common.WithOperation(ctx, "PlaylistModify")
 	service, err := a.newService(ctx, authToken)
 	if err != nil {
 		return "", fmt.Errorf("failed to create YouTube client: %w", err)
@@ -173,7 +177,7 @@ func (a *Adapter) CreatePlaylist(ctx context.Context, name string, description s
 		},
 	}
 
-	call := service.Playlists.Insert([]string{"snippet", "status"}, ytPlaylist)
+	call := service.Playlists.Insert([]string{"snippet", "status"}, ytPlaylist).Context(ctx)
 	created, err := call.Do()
 	if err != nil {
 		return "", fmt.Errorf("failed to create playlist on YouTube: %w", err)
@@ -183,6 +187,7 @@ func (a *Adapter) CreatePlaylist(ctx context.Context, name string, description s
 }
 
 func (a *Adapter) MatchTrack(ctx context.Context, track *converterv1.CanonicalTrack, authToken string) (string, error) {
+	ctx = common.WithOperation(ctx, "Search")
 	service, err := a.newService(ctx, authToken)
 	if err != nil {
 		return "", fmt.Errorf("failed to create YouTube client: %w", err)
@@ -193,7 +198,8 @@ func (a *Adapter) MatchTrack(ctx context.Context, track *converterv1.CanonicalTr
 		call := service.Search.List([]string{"id", "snippet"}).
 			Q(track.Isrc).
 			Type("video").
-			MaxResults(3)
+			MaxResults(3).
+			Context(ctx)
 		response, err := call.Do()
 		if err == nil && len(response.Items) > 0 {
 			for _, item := range response.Items {
@@ -228,7 +234,8 @@ func (a *Adapter) MatchTrack(ctx context.Context, track *converterv1.CanonicalTr
 	call := service.Search.List([]string{"id", "snippet"}).
 		Q(searchQuery).
 		Type("video").
-		MaxResults(3)
+		MaxResults(3).
+		Context(ctx)
 
 	response, err := call.Do()
 	if err != nil {
@@ -269,13 +276,14 @@ func (a *Adapter) MatchTrack(ctx context.Context, track *converterv1.CanonicalTr
 
 // AddTrackToPlaylist inserts a single matched video into a YouTube playlist.
 func (a *Adapter) AddTrackToPlaylist(ctx context.Context, playlistID string, trackID string, authToken string) error {
+	ctx = common.WithOperation(ctx, "PlaylistModify")
 	service, err := a.newService(ctx, authToken)
 	if err != nil {
 		return fmt.Errorf("failed to create YouTube client: %w", err)
 	}
 
 	if playlistID == "LIKED_SONGS" {
-		call := service.Videos.Rate(trackID, "like")
+		call := service.Videos.Rate(trackID, "like").Context(ctx)
 		err = call.Do()
 		if err != nil {
 			return fmt.Errorf("failed to like video %s: %w", trackID, err)
@@ -293,7 +301,7 @@ func (a *Adapter) AddTrackToPlaylist(ctx context.Context, playlistID string, tra
 		},
 	}
 
-	insertCall := service.PlaylistItems.Insert([]string{"snippet"}, playlistItem)
+	insertCall := service.PlaylistItems.Insert([]string{"snippet"}, playlistItem).Context(ctx)
 	_, err = insertCall.Do()
 	if err != nil {
 		return fmt.Errorf("failed to insert video %s into playlist: %w", trackID, err)


### PR DESCRIPTION
This PR adds custom explicit bucket boundaries for latency histograms to improve quantile calculation accuracy and introduces an 'operation' label to classify outgoing API requests without URL cardinality pollution.