### PR TITLE
feat(telemetry): add PORTIFY_ENV environment label to telemetry resources and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ YOUTUBE_SECRET="your_google_cloud_client_secret"
 TIDAL_ID="your_tidal_client_id"
 TIDAL_SECRET="your_tidal_client_secret"
 FRONTEND_URL="http://127.0.0.1:5175/"
+PORTIFY_ENV="local" # Defines telemetry environment (e.g. local, staging, production)
 ```
 
 > **Important:** The `FRONTEND_URL` must exactly match the authorized Redirect URI configured in both the Spotify and Google Cloud developer consoles (including the trailing slash).
@@ -123,6 +124,7 @@ To push traces and metrics automatically to an OTLP-compatible receiver (like Gr
 OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-prod-us-west-0.grafana.net/otlp"
 OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <base64_encoded_token>"
 OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
+PORTIFY_ENV="staging" # Labels all metrics/spans with 'environment' (defaults to 'local' if omitted)
 ```
 
 ### Metrics Collected

--- a/internal/adapters/common/telemetry.go
+++ b/internal/adapters/common/telemetry.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	otelprom "go.opentelemetry.io/otel/exporters/prometheus"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"

--- a/internal/adapters/common/telemetry.go
+++ b/internal/adapters/common/telemetry.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	otelprom "go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -34,10 +35,15 @@ var (
 // InitTelemetry initializes the OTel Tracing and Metrics pipelines.
 // Returns a shutdown function to flush data on server exit.
 func InitTelemetry(ctx context.Context) func(context.Context) {
-	// Create resource
+	// Create resource with environment attribute
+	env := os.Getenv("PORTIFY_ENV")
+	if env == "" {
+		env = "local"
+	}
 	res, err := resource.New(ctx,
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String("portify-backend"),
+			attribute.String("environment", env),
 		),
 	)
 	if err != nil {

--- a/internal/adapters/common/telemetry_test.go
+++ b/internal/adapters/common/telemetry_test.go
@@ -16,6 +16,10 @@ func TestTelemetry_Disabled(t *testing.T) {
 	os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
 	defer os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", origEndpoint)
 
+	origEnv := os.Getenv("PORTIFY_ENV")
+	os.Setenv("PORTIFY_ENV", "test-local")
+	defer os.Setenv("PORTIFY_ENV", origEnv)
+
 	ctx := context.Background()
 	shutdown := InitTelemetry(ctx)
 	defer shutdown(ctx)

--- a/monitoring/grafana_dashboard.json
+++ b/monitoring/grafana_dashboard.json
@@ -92,7 +92,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(portify_conversions_total{status=\"success\"}) or on() vector(0)",
+          "expr": "sum(portify_conversions_total{environment=~\"^$environment$\", status=\"success\"}) or on() vector(0)",
           "legendFormat": "Successful Conversions",
           "range": true,
           "refId": "A"
@@ -160,7 +160,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(portify_conversions_total{status=\"failed\"}) or on() vector(0)",
+          "expr": "sum(portify_conversions_total{environment=~\"^$environment$\", status=\"failed\"}) or on() vector(0)",
           "legendFormat": "Failed Conversions",
           "range": true,
           "refId": "A"
@@ -230,7 +230,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(portify_conversions_total) by (status)",
+          "expr": "sum(portify_conversions_total{environment=~\"^$environment$\"}) by (status)",
           "legendFormat": "{{status}}",
           "range": true,
           "refId": "A"
@@ -268,7 +268,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(portify_conversions_total[5m])) by (source, destination, status)",
+          "expr": "sum(rate(portify_conversions_total{environment=~\"^$environment$\"}[5m])) by (source, destination, status)",
           "legendFormat": "{{source}} \u2794 {{destination}} ({{status}})",
           "range": true,
           "refId": "A"
@@ -327,7 +327,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(portify_tracks_processed_total) by (provider, status)",
+          "expr": "sum(portify_tracks_processed_total{environment=~\"^$environment$\"}) by (provider, status)",
           "legendFormat": "{{provider}} - {{status}}",
           "range": true,
           "refId": "A"
@@ -377,7 +377,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(portify_api_latency_seconds_bucket[5m])) by (le, provider, operation))",
+          "expr": "histogram_quantile(0.95, sum(rate(portify_api_latency_seconds_bucket{environment=~\"^$environment$\"}[5m])) by (le, provider, operation))",
           "legendFormat": "p95 {{provider}} ({{operation}})",
           "range": true,
           "refId": "A"
@@ -415,7 +415,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(portify_api_requests_total[5m])) by (provider, operation, status_code)",
+          "expr": "sum(rate(portify_api_requests_total{environment=~\"^$environment$\"}[5m])) by (provider, operation, status_code)",
           "legendFormat": "{{provider}} [{{operation}}] ({{status_code}})",
           "range": true,
           "refId": "A"
@@ -465,7 +465,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(portify_api_retries_total[5m])) by (provider, operation, attempt, status_code)",
+          "expr": "sum(rate(portify_api_retries_total{environment=~\"^$environment$\"}[5m])) by (provider, operation, attempt, status_code)",
           "legendFormat": "{{provider}} [{{operation}}] (attempt {{attempt}}, code {{status_code}})",
           "range": true,
           "refId": "A"
@@ -484,6 +484,26 @@
   ],
   "templating": {
     "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(environment)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "environment",
+        "query": {
+          "query": "label_values(environment)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "query"
+      },
       {
         "current": {},
         "hide": 0,


### PR DESCRIPTION
This PR adds environment-level tagging ('PORTIFY_ENV') to all OpenTelemetry traces and metrics, and updates the Grafana dashboard JSON with an environment variable dropdown filter.